### PR TITLE
Поиск типов (Lookup Types) — опечатка

### DIFF
--- a/chapters/Оператор keyof, Lookup Types, Mapped Types, Mapped Types - префиксы + и -.md
+++ b/chapters/Оператор keyof, Lookup Types, Mapped Types, Mapped Types - префиксы + и -.md
@@ -105,7 +105,7 @@ interface IInterfaceType {
 }
 
 let v1: IInterfaceType['p1']; // v1: number
-let v2: IInterfaceType['p2']; // p2: number
+let v2: IInterfaceType['p2']; // v2: string
 let union: IInterfaceType['p1' | 'p2']; // union: number | string
 let notexist: IInterfaceType['notexist']; // Error -> Property 'notexist' does not exist on type 'IAnimal'
 ~~~~~


### PR DESCRIPTION
В примере указан не тот тип и название переменной